### PR TITLE
Replace repository URLs with omniosce (r151022 branch)

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -22,7 +22,7 @@ fail() {
 
 # NOTE --> The URL needs to be updated with every release.
 PUBLISHER=omnios
-: ${PKGURL:=https://pkg.omniti.com/omnios/r151022}
+: ${PKGURL:=https://pkg.omniosce.org/r151022/core}
 : ${GZIP_CMD:=gzip}
 SRCDIR=$(dirname $0)
 DIDWORK=0

--- a/build_zfs_send.sh
+++ b/build_zfs_send.sh
@@ -23,8 +23,8 @@ fail() {
 # NOTE --> The URL needs to be updated with every release.  
 # Change "bloody" to whatever release the current branch is.
 PUBLISHER=omnios
-OMNIOS_URL=https://pkg.omniti.com/omnios/r151022
-: ${PKGURL:=https://pkg.omniti.com/omnios/r151022}
+OMNIOS_URL=https://pkg.omniosce.org/r151022/core
+: ${PKGURL:=https://pkg.omniosce.org/r151022/core}
 : ${BZIP2:=bzip2}
 ZROOT=rpool
 OUT=


### PR DESCRIPTION
Update the source repositories used for kayak builds.
This is for the r151022 branch.