### PR TITLE
Retrieve boot components from image instead of running system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,14 @@ INSTALLS=anon.dtrace.conf anon.system build_image.sh build_zfs_send.sh \
 	loader.conf.local rpool-install.sh \
 	sample/000000000000.sample sample/menu.lst.000000000000
 
-TFTP_FILES=$(DESTDIR)/tftpboot/boot/platform/i86pc/kernel/amd64/unix \
+TFTP_FILES=\
 	$(DESTDIR)/tftpboot/kayak/miniroot.gz \
 	$(DESTDIR)/tftpboot/kayak/miniroot.gz.hash \
 	$(DESTDIR)/tftpboot/boot/grub/menu.lst \
-	$(DESTDIR)/tftpboot/pxeboot $(DESTDIR)/tftpboot/boot/loader.conf.local \
+	$(DESTDIR)/tftpboot/boot/loader.conf.local \
 	$(DESTDIR)/tftpboot/boot/forth $(DESTDIR)/tftpboot/boot/defaults \
-	$(DESTDIR)/tftpboot/pxegrub
+	$(DESTDIR)/tftpboot/boot/platform/i86pc/kernel/amd64/unix \
+	$(DESTDIR)/tftpboot/pxeboot $(DESTDIR)/tftpboot/pxegrub
 
 WEB_FILES=$(DESTDIR)/var/kayak/kayak/$(VERSION).zfs.bz2
 IMG_FILES=corner.png tail_bg_v1.png OmniOS_logo_medium.png tail_bg_v2.png
@@ -52,25 +53,25 @@ $(BUILDSEND_MP)/kayak_$(VERSION).zfs.bz2:	build_zfs_send.sh
 	@test -d "$(BUILDSEND_MP)" || (echo "$(BUILDSEND) missing" && false)
 	./build_zfs_send.sh -d $(BUILDSEND) $(VERSION)
 
-$(DESTDIR)/tftpboot/pxegrub:	/boot/grub/pxegrub
+$(DESTDIR)/tftpboot/pxegrub:	$(BUILDSEND_MP)/root/boot/grub/pxegrub
 	cp -p $< $@
 
-$(DESTDIR)/tftpboot/pxeboot:	/boot/pxeboot
+$(DESTDIR)/tftpboot/pxeboot:	$(BUILDSEND_MP)/root/boot/pxeboot
 	cp -p $< $@
 
 $(DESTDIR)/tftpboot/boot/loader.conf.local:	loader.conf.local
 	cp -p $< $@
 
-$(DESTDIR)/tftpboot/boot/forth:	/boot/forth
+$(DESTDIR)/tftpboot/boot/forth:	$(BUILDSEND_MP)/root/boot/forth
 	cp -rp $< $@
 
-$(DESTDIR)/tftpboot/boot/defaults:	/boot/defaults
+$(DESTDIR)/tftpboot/boot/defaults:	$(BUILDSEND_MP)/root/boot/defaults
 	cp -rp $< $@
 
 $(DESTDIR)/tftpboot/boot/grub/menu.lst:	sample/menu.lst.000000000000
 	sed -e 's/@VERSION@/$(VERSION)/' $< > $@
 
-$(DESTDIR)/tftpboot/boot/platform/i86pc/kernel/amd64/unix:	/platform/i86pc/kernel/amd64/unix
+$(DESTDIR)/tftpboot/boot/platform/i86pc/kernel/amd64/unix:	$(BUILDSEND_MP)/root/platform/i86pc/kernel/amd64/unix
 	cp -p $< $@
 
 $(DESTDIR)/tftpboot/kayak/miniroot.gz:	$(BUILDSEND_MP)/miniroot.gz

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ machine's SMF services.
 
 <target> must be specified.
 
-install-http:
+install-web:
 	Builds the <VERSION>.zfs.bz2 file, which is what Kayak uses
 	for any install it does. Independent target.
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -110,6 +110,7 @@ UNNEEDED_MANIFESTS="application/management/net-snmp.xml
 
 SYSTEM="system/boot/real-mode system/boot/wanboot/internal
 	system/boot/loader system/boot/wanboot system/data/hardware-registry
+	system/boot/grub
 	system/data/keyboard/keytables system/data/terminfo
 	system/data/zoneinfo system/extended-system-utilities
 	system/file-system/autofs system/file-system/nfs

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -60,9 +60,10 @@ gunzip -c $KAYAK_ROOTBALL > $KR_FILE
 LOFI_RPATH=`lofiadm -a $KR_FILE`
 mkdir $KAYAK_ROOT
 mount $LOFI_RPATH $KAYAK_ROOT
-tar -cf - -C $KAYAK_ROOT . | tar -xf - -C $MNT
+echo "Adding files from miniroot"
+tar -cf - -C $KAYAK_ROOT . | pv | tar -xf - -C $MNT
 mkdir $PROTO
-tar -cf - -C $KAYAK_ROOT . | tar -xf - -C $PROTO
+tar -cf - -C $KAYAK_ROOT . | pv | tar -xf - -C $PROTO
 umount $KAYAK_ROOT
 rmdir $KAYAK_ROOT
 lofiadm -d $LOFI_RPATH
@@ -74,7 +75,8 @@ rm $KR_FILE
 # 
 
 # The full ZFS image (also already-created) for actual installation.
-cp $ZFS_IMG $MNT/root/.
+echo "Adding ZFS image"
+pv $ZFS_IMG > $MNT/root/`basename $ZFS_IMG`
 
 # A cheesy way to get the boot menu to appear at boot time.
 cp -p ./takeover-console $MNT/kayak/.
@@ -137,7 +139,8 @@ EOF
 #
 umount $MNT
 lofiadm -d $LOFI_PATH
-cp $UFS_LOFI $PROTO/platform/i86pc/amd64/boot_archive
+echo "Installing boot archive"
+pv $UFS_LOFI > $PROTO/platform/i86pc/amd64/boot_archive
 digest -a sha1 $UFS_LOFI > $PROTO/platform/i86pc/amd64/boot_archive.hash
 rm -rf $PROTO/{usr,bin,sbin,lib,kernel}
 du -sh $PROTO/.

--- a/build_zfs_send.sh
+++ b/build_zfs_send.sh
@@ -24,7 +24,7 @@ fail() {
 # Change "bloody" to whatever release the current branch is.
 PUBLISHER=omnios
 OMNIOS_URL=https://pkg.omniosce.org/bloody/core
-: ${PKGURL:=https://pkg.omniosce.org/bloody/core}
+: ${PKGURL:=$OMNIOS_URL}
 : ${BZIP2:=bzip2}
 ZROOT=rpool
 OUT=
@@ -60,12 +60,7 @@ else
   zfs create $ZROOT/$name || fail "zfs create"
   MP=`zfs get -H mountpoint $ZROOT/$name | awk '{print $3}'`
   pkg image-create -F -p $PUBLISHER=$PKGURL $MP || fail "image-create"
-  # If r151006, use a specific version to avoid missing incorporation
-  if [[ "$name" == "r151006" ]]; then
-    entire_version="151006:20131210T224515Z"
-  else
-    entire_version=${name//r/}
-  fi
+  entire_version=${name//r/}
   pkg -R $MP install entire@11-0.$entire_version openssh-server || fail "install entire"
   zfs snapshot $ZROOT/$name@entire
 fi
@@ -95,15 +90,19 @@ fi
 echo "Setting omnios publisher to $OMNIOS_URL"
 pkg -R $MP unset-publisher omnios
 pkg -R $MP set-publisher -P --no-refresh -g $OMNIOS_URL omnios
-# Starting with r151014, require signatures for the omnios publisher.
-# NOTE:  Uncomment this line when you branch off a release.  "bloody" packages
-# are unsigned, but release ones are, and we should require checking their
-# signatures.
-#pkg -R $MP set-publisher --set-property signature-policy=require-signatures omnios
 
+# Starting with r151014, require signatures for the omnios publisher.
+if [[ $OMNIOS_URL != */bloody/* ]]; then
+  echo "Setting signature policy to require."
+  pkg -R $MP set-publisher \
+    --set-property signature-policy=require-signatures omnios
+fi
+
+echo "Creating compressed stream"
 zfs snapshot $ZROOT/$name@kayak || fail "snap"
-zfs send $ZROOT/$name@kayak | $BZIP2 -9 > $OUT || fail "send/compress"
+zfs send $ZROOT/$name@kayak | pv | $BZIP2 -9 > $OUT || fail "send/compress"
 if [[ "$CLEANUP" -eq "1" ]]; then
   zfs destroy $ZROOT/$name@kayak || fail "could not remove snapshot"
   zfs destroy $ZROOT/$name || fail "could not remove zfs filesystem"
 fi
+


### PR DESCRIPTION
Grab components required for the `kayak-kernel` package from the miniroot that has just been generated (fixes https://github.com/omniosorg/omnios-build/issues/59 )
Show more progress information during media build.
Automatically determine release signing policy by looking at publisher URL (one less change required when branching for new release)