### PR TITLE
Kayak cleanups

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -13,6 +13,7 @@
 
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 #
 
 fail() {
@@ -29,21 +30,21 @@ SRCDIR=$(dirname $0)
 DIDWORK=0
 BUILDNUM=${VERSION//r/}
 if [[ ${SRCDIR:0:1} != "/" ]]; then
-  SRCDIR=`pwd`/$SRCDIR
+	SRCDIR=`pwd`/$SRCDIR
 fi
 if [[ -z "${1}" ]]; then
-  echo "$0 <zfs pool> [checkpoint]"
-  exit 1
+	echo "$0 <zfs pool> [checkpoint]"
+	exit 1
 else
-  BASE=${1}
-  shift
-  BASEDIR=`zfs get -o value -H mountpoint $BASE`
+	BASE=${1}
+	shift
+	BASEDIR=`zfs get -o value -H mountpoint $BASE`
 fi
 MKFILEDIR=/tmp
 WORKDIR=$BASEDIR
 ROOTDIR=$WORKDIR/root
 if [[ ! -d $ROOTDIR ]]; then
-  zfs create -o compression=off $BASE/root || fail "zfs create failed"
+	zfs create -o compression=off $BASE/root || fail "zfs create failed"
 fi
 SVCCFG_DTD=${ROOTDIR}/usr/share/lib/xml/dtd/service_bundle.dtd.1
 SVCCFG_REPOSITORY=${ROOTDIR}/etc/svc/repository.db
@@ -235,37 +236,44 @@ load_keep_list() {
 }
 
 step() {
-	CHKPT=""
-	case "$1" in
+    CHKPT=""
+    case "$1" in
 
-	"begin")
+    "begin")
 	zfs destroy -r $BASE/root 2> /dev/null
 	zfs create -o compression=off $BASE/root || fail "zfs create failed"
 	chkpt pkg
 	;;
 
-	"pkg")
+    "pkg")
 
 	echo "Creating image of $PUBLISHER from $PKGURL"
-	$PKG image-create -F -p $PUBLISHER=$PKGURL $ROOTDIR || fail "image-create"
+	$PKG image-create -F -p $PUBLISHER=$PKGURL $ROOTDIR \
+	    || fail "image-create"
         # If a version was requested, respect it
 	if [[ -n $BUILDNUM ]]; then
-		$PKG -R $ROOTDIR install illumos-gate@11-0.$BUILDNUM omnios-userland@11-0.$BUILDNUM || fail "version constraint prep"
+		$PKG -R $ROOTDIR install illumos-gate@11-0.$BUILDNUM \
+		    omnios-userland@11-0.$BUILDNUM \
+		    || fail "version constraint prep"
 	fi
 	$PKG -R $ROOTDIR install $PKGS || fail "install"
 	if [[ -n $BUILDNUM ]]; then
-		$PKG -R $ROOTDIR uninstall illumos-gate omnios-userland || fail "version constraint cleanup"
+		$PKG -R $ROOTDIR uninstall illumos-gate omnios-userland \
+		    || fail "version constraint cleanup"
 	fi
 	chkpt fixup
 	;;
 
-	"fixup")
+    "fixup")
 
 	echo "Fixing up install root"
-	(cp $ROOTDIR/etc/vfstab $WORKDIR/vfstab && \
-		awk '{if($3!="/"){print;}}' $WORKDIR/vfstab > $ROOTDIR/etc/vfstab && \
-		echo "/devices/ramdisk:a - / ufs - no nologging" >> $ROOTDIR/etc/vfstab) || \
-		fail "vfstab / updated"
+	(
+		cp $ROOTDIR/etc/vfstab $WORKDIR/vfstab && \
+		    awk '{if($3!="/"){print;}}' $WORKDIR/vfstab \
+		    > $ROOTDIR/etc/vfstab && \
+		echo "/devices/ramdisk:a - / ufs - no nologging" \
+		    >> $ROOTDIR/etc/vfstab
+	) || fail "vfstab / updated"
 	rm $WORKDIR/vfstab
 	cp $ROOTDIR/lib/svc/seed/global.db $ROOTDIR/etc/svc/repository.db
 
@@ -273,7 +281,8 @@ step() {
 
 	${SVCCFG} import ${ROOTDIR}/lib/svc/manifest/milestone/sysconfig.xml
 	for xml in $UNNEEDED_MANIFESTS; do
-		rm -f ${ROOTDIR}/lib/svc/manifest/$xml && echo " --- tossing $xml"
+		rm -f ${ROOTDIR}/lib/svc/manifest/$xml && \
+		    echo " --- discarding $xml"
 	done
 	echo " --- initial manifest import"
 	# See if we can transform manifest-import to use the 'native' svccfg.
@@ -288,16 +297,30 @@ step() {
 
 	${SVCCFG} -s 'system/boot-archive' setprop 'start/exec=:true'
 	${SVCCFG} -s 'system/manifest-import' setprop 'start/exec=:true'
-	${SVCCFG} -s "system/intrd:default" setprop "general/enabled=false"
+	# system/intrd is discarded above
+	#${SVCCFG} -s "system/intrd:default" setprop "general/enabled=false"
 	${SVCCFG} -s "system/initial-boot" setprop "start/timeout_seconds=600"
+
 	echo " --- neutering the manifest import"
         echo "#!/bin/ksh" > ${ROOTDIR}/lib/svc/method/manifest-import
         echo "exit 0" >> ${ROOTDIR}/lib/svc/method/manifest-import
 	chmod 555 ${ROOTDIR}/lib/svc/method/manifest-import
+
+	echo " --- neutering hostname message on boot"
+	sed -i '/dev\/msglog/s/^/#/' ${ROOTDIR}/lib/svc/method/identity-node
+
+	echo " --- removing locale call from tzselect"
+	# The line in gettext is broken anyway. /bin/who is present
+	# in the miniroot and does not return any output. It will do.
+	sed -i '
+		/^LOCALE=/s^=.*^=/bin/who^
+		s/is_C=0/is_C=1/
+	' ${ROOTDIR}/usr/bin/tzselect
+
 	chkpt cull
 	;;
 
-	"cull")
+    "cull")
 	if [[ -z "$BIGROOT" ]]; then
 		load_keep_list data/*
 		while read file
@@ -310,32 +333,34 @@ step() {
 			fi
 		done < <(cd $ROOTDIR && find ./ | cut -c3-)
 		for path in $RMRF ; do
-			rm -rf ${ROOTDIR}$path && echo " -- tossing $path"	
+			rm -rf ${ROOTDIR}$path && echo " -- discarding $path"
 		done
 	fi
 
 	chkpt mkfs
 	;;
 
-	"mkfs")
+    "mkfs")
 	size=`/usr/bin/du -ks ${ROOTDIR}|/usr/bin/nawk '{print $1+10240}'`
 	echo " --- making image of size $size"
 	/usr/sbin/mkfile ${size}k $MKFILEDIR/miniroot || fail "mkfile"
 	lofidev=`/usr/sbin/lofiadm -a $MKFILEDIR/miniroot`
 	rlofidev=`echo $lofidev |sed s/lofi/rlofi/`
-	yes | /usr/sbin/newfs -m 0 $rlofidev 2> /dev/null > /dev/null || fail "newfs"
+	yes | /usr/sbin/newfs -m 0 $rlofidev 2> /dev/null > /dev/null \
+	    || fail "newfs"
 	chkpt mount
 	;;
 
-	"mount")
+    "mount")
 	mkdir -p $WORKDIR/mnt
 	/usr/sbin/mount -o nologging $lofidev $WORKDIR/mnt || fail "mount"
 	chkpt copy
 	;;
 
-	"copy")
+    "copy")
 	pushd $ROOTDIR >/dev/null
-	/usr/bin/find . | /usr/bin/cpio -pdum $WORKDIR/mnt 2> /dev/null > /dev/null || fail "populate root"
+	/usr/bin/find . | /usr/bin/cpio -pdum $WORKDIR/mnt 2>&1 >/dev/null \
+	    || fail "populate root"
 	/usr/sbin/devfsadm -r $WORKDIR/mnt > /dev/null
 	popd >/dev/null
 	mkdir $WORKDIR/mnt/kayak
@@ -354,13 +379,13 @@ step() {
 	chkpt umount
 	;;
 
-	"umount")
+    "umount")
 	/usr/sbin/umount $WORKDIR/mnt || fail "umount"
 	/usr/sbin/lofiadm -d $MKFILEDIR/miniroot || fail "lofiadm delete"
 	chkpt compress
 	;;
 
-	"compress")
+    "compress")
 	$GZIP_CMD -c -f $MKFILEDIR/miniroot > $WORKDIR/miniroot.gz
 	rm -f $MKFILEDIR/miniroot
 	chmod 644 $WORKDIR/miniroot.gz
@@ -368,7 +393,7 @@ step() {
 	ls -l $WORKDIR/miniroot.gz
 	;;
 
-	esac
+    esac
 }
 
 make_initial_boot() {
@@ -382,3 +407,4 @@ EOF
 while [[ -n "$CHKPT" ]]; do
 	step $CHKPT
 done
+

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -147,7 +147,18 @@ rm -rf $PROTO/{usr,bin,sbin,lib,kernel}
 du -sh $PROTO/.
 
 # And finally, burn the ISO.
-mkisofs -o $DST_ISO -b boot/cdboot -c .catalog -no-emul-boot -boot-load-size 4 -boot-info-table -N -l -R -U -allow-multidot -no-iso-translate -cache-inodes -d -D -V "OmniOSce $VERSION" $PROTO
+mkisofs -N -l -R -U -d -D \
+	-o $DST_ISO \
+	-b boot/cdboot \
+	-c .catalog \
+	-no-emul-boot \
+	-boot-load-size 4 \
+	-boot-info-table \
+	-allow-multidot \
+	-no-iso-translate \
+	-cache-inodes \
+	-V "OmniOSce $VERSION" \
+	$PROTO
 
 rm -rf $PROTO $UFS_LOFI
 echo "$DST_ISO is ready"

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -13,6 +13,7 @@
 
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #
@@ -30,7 +31,7 @@ if [[ -z $BUILDSEND_MP ]]; then
 fi
 
 if [[ -z $VERSION ]]; then
-	VERSION=`grep OmniOS $BUILDSEND_MP/root/etc/release | awk '{print $3}'`
+	VERSION=`head -1 $BUILDSEND_MP/root/etc/release | awk '{print $3}'`
 	echo "Using $VERSION..."
 fi
 
@@ -129,7 +130,7 @@ from_one_to_other usr/bin netstat
 
 # Remind people this is the installer.
 cat <<EOF > $PROTO/boot/loader.conf.local
-loader_menu_title="Welcome to the OmniOS installer"
+loader_menu_title="Welcome to the OmniOSce installer"
 autoboot_delay=5
 EOF
 
@@ -146,7 +147,7 @@ rm -rf $PROTO/{usr,bin,sbin,lib,kernel}
 du -sh $PROTO/.
 
 # And finally, burn the ISO.
-mkisofs -o $DST_ISO -b boot/cdboot -c .catalog -no-emul-boot -boot-load-size 4 -boot-info-table -N -l -R -U -allow-multidot -no-iso-translate -cache-inodes -d -D -V OmniOS $PROTO
+mkisofs -o $DST_ISO -b boot/cdboot -c .catalog -no-emul-boot -boot-load-size 4 -boot-info-table -N -l -R -U -allow-multidot -no-iso-translate -cache-inodes -d -D -V "OmniOSce $VERSION" $PROTO
 
 rm -rf $PROTO $UFS_LOFI
 echo "$DST_ISO is ready"

--- a/install_help.sh
+++ b/install_help.sh
@@ -109,8 +109,12 @@ BuildBE() {
   fi
   zfs set compression=on $RPOOL
   zfs create $RPOOL/ROOT
-  zfs set canmount=off $RPOOL/ROOT
-  zfs set mountpoint=legacy $RPOOL/ROOT
+  # The miniroot does not have any libshare SMF services so the following
+  # commands print an error.
+  (
+	zfs set canmount=off $RPOOL/ROOT
+	zfs set mountpoint=legacy $RPOOL/ROOT
+  ) | grep -v 'libshare SMF'
   log "Receiving image: $MEDIA"
   $GRAB $MEDIA | pv -B 128m -w 78 | $DECOMP | zfs receive -u $RPOOL/ROOT/omnios
   zfs set canmount=noauto $RPOOL/ROOT/omnios
@@ -122,6 +126,7 @@ BuildBE() {
   BEUUID=`LD_LIBRARY_PATH=$ALTROOT/lib:$ALTROOT/usr/lib $ALTROOT/usr/bin/uuidgen`
   zfs set org.opensolaris.libbe:uuid=$BEUUID $RPOOL/ROOT/omnios
   zfs set org.opensolaris.libbe:policy=static $RPOOL/ROOT/omnios
+  log "Setting BE UUID: $BEUUID"
   cp $ALTROOT/lib/svc/seed/global.db $ALTROOT/etc/svc/repository.db
   chmod 0600 $ALTROOT/etc/svc/repository.db
   chown root:sys $ALTROOT/etc/svc/repository.db

--- a/kayak-menu.sh
+++ b/kayak-menu.sh
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2017 OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 #
 
 # This started its life as the Caiman text-installer menu, hence the old
@@ -52,27 +53,27 @@ klang=`grep -w $layout /usr/share/lib/keytables/type_$ktype/kbd_layouts | awk -F
 
 # Define the menu of commands and prompts
 menu_items=( \
-    (menu_str="Find disks, create rpool, and install OmniOS"		 \
+    (menu_str="Find disks, create rpool, and install OmniOSce"		 \
 	cmds=("/kayak/find-and-install.sh $klang")			 \
 	do_subprocess="true"						 \
 	msg_str="")							 \
-    (menu_str="Install OmniOS straight on to a preconfigured rpool"	 \
+    (menu_str="Install OmniOSce straight on to a preconfigured rpool"	 \
 	cmds=("/kayak/rpool-install.sh rpool $klang")			 \
 	do_subprocess="true"						 \
 	msg_str="")							 \
     (menu_str="Shell (for manual rpool creation, or post-install ops on /mnt)" \
 	cmds=("$ROOT_SHELL")						 \
 	do_subprocess="true"						 \
-	msg_str="To return to the main menu, exit the shell")	 \
+	msg_str="To return to the main menu, exit the shell")		 \
     # this string gets overwritten every time $TERM is updated
-    (menu_str="Terminal type (currently ""$TERM)"		 \
+    (menu_str="Terminal type (currently ""$TERM)"			 \
 	cmds=("prompt_for_term_type")					 \
 	do_subprocess="false"						 \
 	msg_str="")							 \
-    (menu_str="Reboot"					 \
+    (menu_str="Reboot"							 \
 	cmds=("/usr/sbin/reboot" "/usr/bin/sleep 10000")		 \
 	do_subprocess="true"						 \
-	msg_str="")							 \
+	msg_str="Restarting, please wait...")				 \
 )
 
 # Update the menu_str for the terminal type
@@ -159,7 +160,7 @@ for ((;;)) ; do
 	stty sane
 	clear
 	printf \
-	    "Welcome to the OmniOS installation menu"
+	    "Welcome to the OmniOSce installation menu"
 	print " \n\n"
 	for i in "${!menu_items[@]}"; do
 		print "\t$((${i} + 1))  ${menu_items[$i].menu_str}"
@@ -202,6 +203,14 @@ for ((;;)) ; do
 		[[ ! -z "${msg_str}" ]] && printf "%s\n" "${msg_str}"
 		for j in "${!menu_items[$input].cmds[@]}"; do
 			${menu_items[${input}].cmds[$j]}
+		done
+	fi
+
+	# Although the 'Reboot' action starts a long running
+	# sleep, the shutdown process kills that early on.
+	if [ "${menu_items[$input].menu_str}" = "Reboot" ] ; then
+		while :; do
+			sleep 10000
 		done
 	fi
 done


### PR DESCRIPTION
These are a few cleanups in the kayak installation process to remove error messages and other unwanted output. For the files I've touched, I've also reformatted whitespace where it was inconsistent (standardising on illumos style including 80 columns).

Whitespace changes aside:

* Do not show 'Hostname: unknown' at the keyboard selection prompt;
* Remove error about locale before timezone select menu;
* Remove errors about libshare SMF during rpool creation;
* Fix for retrieving version number from /etc/release now that `OmniOS` appears on two lines;
* Add `ce` to menu titles;
* When choosing reboot from the kayak installation menu, show a restarting message and do not return to the menu;
* Add release version to ISO volume label.

An iso file built with this amended kayak can be found at https://downloads.omniosce.org/media/bloody/.test/omniosce-bloody-20170722.iso

Due to the fix for determining the OmniOS version, that part at least needs backporting. However, as it improves the installation experience, I'll backport everything.