### PR TITLE
Exclude man pages from miniroot

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -250,6 +250,7 @@ step() {
 	echo "Creating image of $PUBLISHER from $PKGURL"
 	$PKG image-create -F -p $PUBLISHER=$PKGURL $ROOTDIR \
 	    || fail "image-create"
+	$PKG -R $ROOTDIR change-facet doc.man=false
         # If a version was requested, respect it
 	if [[ -n $BUILDNUM ]]; then
 		$PKG -R $ROOTDIR install illumos-gate@11-0.$BUILDNUM \


### PR DESCRIPTION
Simple change that stops man pages (or at least, anything marked with the `doc` facet) from being included in the miniroot. This doesn't reduce the size much (~13KiB) but removes a lot of unnecessary small files.