### PR TITLE
Stop modifying system file contents/ownership...

### DIFF
--- a/install_help.sh
+++ b/install_help.sh
@@ -226,13 +226,13 @@ SetKeyboardLayout()
       # "setprop keyboard-layout <foo>" in the newly-installed root's
       # /boot/solaris/bootenv.rc (aka. eeprom(1M) storage for amd64/i386).
       layout=$1
-      sed "s/keyboard-layout Unknown/keyboard-layout $layout/g" \
-	  < $ALTROOT/boot/solaris/bootenv.rc > /tmp/bootenv.rc
-      mv /tmp/bootenv.rc $ALTROOT/boot/solaris/bootenv.rc
-      # Also modify the SMF manifest, assuming US-English was set by default.
-      sed "s/US-English/$layout/g" \
-	 < $ALTROOT/lib/svc/manifest/system/keymap.xml > /tmp/keymap.xml
-      cp -f /tmp/keymap.xml $ALTROOT/lib/svc/manifest/system/keymap.xml
+      sed -i "s/keyboard-layout Unknown/keyboard-layout $layout/g" \
+	  $ALTROOT/boot/solaris/bootenv.rc
+      # Also modify the system/keymap service
+      Postboot "/usr/sbin/svccfg -s system/keymap:default"\
+         "setprop keymap/layout = '$layout'"
+      Postboot "/usr/sbin/svcadm refresh system/keymap:default"
+      Postboot "/usr/sbin/svcadm restart system/keymap:default"
 }
 
 ApplyChanges(){


### PR DESCRIPTION
... as it causes `pkg verify` failures..

On a freshly installed bloody system, `pkg verify` shows:

```
root@omniosce:~# pkg verify
PACKAGE                                                                 STATUS
pkg://omnios/SUNWcs                                                      ERROR
        file: lib/svc/manifest/system/keymap.xml
                ERROR: Hash: 77fe48b5ab730f8658cd8fa65ca5c0998c7f5aa0 should be bac5dc062bb31b946dc03342f88cca4bdea89351
pkg://omnios/system/boot/real-mode                                       ERROR
        file: boot/solaris/bootenv.rc
                ERROR: Group: 'root (0)' should be 'sys (3)'
```

Several verify errors have recently been fixed, this PR fixes these last two.

With this patch, keymap is still correctly set, and pkg verify succeeds:

```
af@omniosce:~$ grep layout /boot/solaris/bootenv.rc
setprop keyboard-layout UK-English

af@omniosce:~$ svcprop system/keymap:default | grep keymap/layout
keymap/layout astring UK-English

af@omniosce:~$ pfexec pkg verify
af@omniosce:~$ echo $?
0
```