### PR TITLE
Add missing loader.rc to kayak-kernel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ TFTP_FILES=\
 	$(DESTDIR)/tftpboot/kayak/miniroot.gz.hash \
 	$(DESTDIR)/tftpboot/boot/grub/menu.lst \
 	$(DESTDIR)/tftpboot/boot/loader.conf.local \
+	$(DESTDIR)/tftpboot/boot/loader.rc \
 	$(DESTDIR)/tftpboot/boot/forth $(DESTDIR)/tftpboot/boot/defaults \
 	$(DESTDIR)/tftpboot/boot/platform/i86pc/kernel/amd64/unix \
 	$(DESTDIR)/tftpboot/pxeboot $(DESTDIR)/tftpboot/pxegrub
@@ -70,8 +71,11 @@ $(DESTDIR)/tftpboot/pxegrub:	$(BUILDSEND_MP)/root/boot/grub/pxegrub
 $(DESTDIR)/tftpboot/pxeboot:	$(BUILDSEND_MP)/root/boot/pxeboot
 	cp -p $< $@
 
-$(DESTDIR)/tftpboot/boot/loader.conf.local:	loader.conf.local
+$(DESTDIR)/tftpboot/boot/loader.rc:	$(BUILDSEND_MP)/root/boot/loader.rc
 	cp -p $< $@
+
+$(DESTDIR)/tftpboot/boot/loader.conf.local:	loader.conf.local
+	sed -e 's/@VERSION@/$(VERSION)/' $< > $@
 
 $(DESTDIR)/tftpboot/boot/forth:	$(BUILDSEND_MP)/root/boot/forth
 	cp -rp $< $@

--- a/loader.conf.local
+++ b/loader.conf.local
@@ -4,13 +4,16 @@
 bootfile="/boot/platform/i86pc/kernel/amd64/unix"
 
 # We need some install boot arguments...
-# NOTE: "x.y.z.a" should be filled in with an actual IP address for the "kayak"
-# service host.
-boot-args="-B install_media=http://x.y.z.a/kayak/r151021-20170314.zfs.bz2,install_config=http://x.y.z.a/kayak"
+
+# Either use http[s]:/// to use the next-server option provided by DHCP...
+boot-args="-B install_media=http:///kayak/@VERSION@.zfs.bz2,install_config=http:///kayak"
+
+# ... or specify an IP address
+#boot-args="-B install_media=http://x.y.z.a/kayak/@VERSION@.zfs.bz2,install_config=http://x.y.z.a/kayak"
 
 # Like the ISO, let people know we're in the PXE installer:
 loader_menu_title="Welcome to the OmniOS PXE Installer"
-autoboot_delay=1
+autoboot_delay=10
 
 # Make sure we're maxed out on TFTP block size.
 tftp.blksize="1428"


### PR DESCRIPTION
A Kayak PXE installation using loader currently fails as loader.rc is missing from kayak-kernel.
In addition to fixing that, this PR updates the loader.conf.local file with another example and will now dynamically update the image version with each release.