### PR TITLE
Improve swap/dump volume configuration

### DIFF
--- a/data/known_extras
+++ b/data/known_extras
@@ -1,5 +1,6 @@
 0 /usr/sbin/reboot
 0 /usr/sbin/installboot
+0 /usr/bin/getconf
 0 /usr/bin/cp
 0 /usr/bin/mv
 0 /usr/bin/wc


### PR DESCRIPTION
* Set the volume block size to match the system page size. This tuning prevents ZFS from having to perform read-modify-write options on a larger block while the system is already low on memory.
* Set the logbias=throughput and sync=always properties. Data written to the volume will be flushed immediately to disk freeing up memory as quickly as possible.
* Set primarycache=metadata to avoid keeping swap data in RAM via the ARC.
* Set secondarycache=none to disable L2ARC for swap.
* Configure dump to include the pages from the currently running process by default.

The dump volume gets the same parameters FWIW as writes to that will be in a panic situation anyway.