### PR TITLE
Add ZFS options menu and more...

### DIFF
--- a/dialog.sh
+++ b/dialog.sh
@@ -41,5 +41,13 @@ if [ -x /kayak/dialog ]; then
 		((width += 5))
 		dialog --msgbox "$@" $lines $width
 	}
+
+	d_centre()
+	{
+		line="$1"
+		cols="${2:-79}"
+
+		printf "%*s" $(((cols + ${#line})/2)) "$line"
+	}
 fi
 

--- a/install_help.sh
+++ b/install_help.sh
@@ -96,7 +96,7 @@ ForceDHCP(){
 BE_Create_Root() {
     local _rpool="${1:?rpool}"
 
-    zfs set compression=on $_rpool
+    [ -z "$NO_COMPRESSION" ] && zfs set compression=on $_rpool
     zfs create $_rpool/ROOT
     # The miniroot does not have any libshare SMF services so the following
     # commands print an error.


### PR DESCRIPTION
A few installer enhancements...

A test iso for this is at https://downloads.omniosce.org/media/bloody/.swamp/omniosce-bloody-20180225.iso

### Loader screen

![screenshot 2018-02-25 16 44 36](https://user-images.githubusercontent.com/29426693/36644001-9001b9e2-1a4b-11e8-918f-5510f0b58846.png)

* Show installer version at the top of the screen - for stable releases this will include the suffix;
* New `boot from hard disk` option.

### ZFS Root Pool

![screenshot 2018-02-25 16 52 03](https://user-images.githubusercontent.com/29426693/36644037-43e964e6-1a4c-11e8-8a9b-bd4052c81532.png)

This is a new interstitial page replacing the previous 'root pool name' screen. The name of the root pool can still be changed via the first option on the menu.
Other menu options are:
* Partitioning scheme - cycles through GPT, MBR, GPT+Active, GPT+Slot1. MBR does not use an EFI/GPT disk label so can be used for older systems that may have issues with EFI labels. The last two options are manual selections for workaround for BIOS bugs.. GPT+Slot1 is the same as 'Lenovofix' on FreeBSD for example.
* Compression - by default lz4 compression is turned on for the root pool. This option allows that to be disabled if required.
* Force 4K Sectors - off by default but if enabled it forces ashift=12 on the root pool even if the disk reports a 512n block size. This is useful if the disk is mis-reporting or if there are plans to replace drives with 4Kn units in the future.
