### PR TITLE
Kayak improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,10 @@ clean:
 ######################################################################
 # Install targets (see README.md)
 
+miniroot:	install-tftp
 install-tftp:	zfscreate tftp-dirs $(TFTP_FILES)
 
+zfs:		install-web
 install-web:	zfscreate server-dirs $(WEB_FILES)
 
 check-mkisofs:

--- a/build/build_iso
+++ b/build/build_iso
@@ -150,11 +150,6 @@ if [ -n "$REFRESH_KAYAK" ]; then
 	done
 fi
 
-cat <<EOF > $BA_ROOT/root/.bashrc
-export PATH=/usr/bin:/usr/sbin:/sbin
-export HOME=/root
-EOF
-
 # Have initialboot invoke an interactive installer.
 cat <<EOF > $BA_ROOT/.initialboot
 /kayak/bin/takeover-console /kayak/installer/kayak-menu

--- a/build/build_miniroot
+++ b/build/build_miniroot
@@ -322,6 +322,13 @@ step() {
         s/is_C=0/is_C=1/
     ' ${ROOTDIR}/usr/bin/tzselect
 
+    echo " --- updating root environment"
+    cat << EOM > $ROOTDIR/root/.bashrc
+export PATH=/usr/bin:/usr/sbin:/sbin
+export HOME=/root
+export PS1='kayak-$VERSION# '
+EOM
+
     chkpt cull
     ;;
 

--- a/build/build_miniroot
+++ b/build/build_miniroot
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#
+# {{{ CDDL HEADER
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
@@ -9,7 +9,7 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-#
+# }}}
 
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
@@ -193,17 +193,16 @@ if [ "$ID" != "0" ]; then
 fi
 
 chkpt() {
-    SNAP=`zfs list -H -t snapshot $BASE/root@${1} 2> /dev/null`
+    SNAP=`zfs list -H -t snapshot $BASE/root@$1 2> /dev/null`
     if [ "$DIDWORK" -ne "0" ]; then
         if [ -n "$SNAP" ]; then
-            zfs destroy $BASE/root@${1} || \
-                fail "zfs destroy ${1} failed"
+            zfs destroy $BASE/root@$1 || fail "zfs destroy $1 failed"
         fi
-        zfs snapshot $BASE/root@${1} || fail "zfs snapshot failed"
+        zfs snapshot $BASE/root@$1 || fail "zfs snapshot failed"
     fi
     if [ "$1" != "begin" ]; then
-        echo " === Proceeding to phase $1 (zfs @${1}) ==="
-        zfs rollback -r $BASE/root@${1} || fail "zfs rollback failed"
+        echo " === Proceeding to phase $1 (zfs @$1) ==="
+        zfs rollback -r $BASE/root@$1 || fail "zfs rollback failed"
     else
         echo " === Proceeding to phase $1 ==="
     fi
@@ -216,9 +215,7 @@ if [ -n "$1" ]; then
     CHKPT=$1
     chkpt $CHKPT
 fi
-if [ -z "$CHKPT" ]; then
-    CHKPT="begin"
-fi
+[ -z "$CHKPT" ] && CHKPT="begin"
 
 declare -A keep_list
 declare -a match_list
@@ -239,7 +236,7 @@ load_keep_list() {
 }
 
 step() {
-    CHKPT=""
+    CHKPT=
     case "$1" in
 
   "begin")
@@ -251,8 +248,8 @@ step() {
   "pkg")
 
     echo "Creating image of $PUBLISHER from $PKGURL"
-    $PKG image-create -F -p $PUBLISHER=$PKGURL $ROOTDIR \
-        || fail "image-create"
+    $PKG image-create -F -p $PUBLISHER=$PKGURL $ROOTDIR || fail "image-create"
+    # No need to install documentation or development files in the miniroot
     $PKG -R $ROOTDIR change-facet doc.man=false
     $PKG -R $ROOTDIR change-facet devel=false
     # If a version was requested, respect it
@@ -273,25 +270,27 @@ step() {
 
     echo "Fixing up install root"
     (
-        cp $ROOTDIR/etc/vfstab $WORKDIR/vfstab && \
-            awk '{if($3!="/"){print;}}' $WORKDIR/vfstab \
-            > $ROOTDIR/etc/vfstab && \
-        echo "/devices/ramdisk:a - / ufs - no nologging" \
-            >> $ROOTDIR/etc/vfstab
+        nawk < $ROOTDIR/etc/vfstab > $WORKDIR/vfstab '
+            $3 != "/" { print }
+            END { print "/devices/ramdisk:a - / ufs - no nologging" }
+        ' && cp $WORKDIR/vfstab $ROOTDIR/etc/vfstab
     ) || fail "vfstab / updated"
     rm $WORKDIR/vfstab
+
+    echo " --- seeding SMF database"
     cp $ROOTDIR/lib/svc/seed/global.db $ROOTDIR/etc/svc/repository.db
 
+    echo " --- allowing empty passwords"
     sed -i 's,PASSREQ=YES,PASSREQ=NO,' $ROOTDIR/etc/default/login
 
+    echo " --- pruning manifests"
     ${SVCCFG} import ${ROOTDIR}/lib/svc/manifest/milestone/sysconfig.xml
     for xml in $UNNEEDED_MANIFESTS; do
-        rm -f ${ROOTDIR}/lib/svc/manifest/$xml && \
-            echo " --- discarding $xml"
+        rm -f ${ROOTDIR}/lib/svc/manifest/$xml && echo "   - discarding $xml"
     done
     echo " --- initial manifest import"
-    # See if we can transform manifest-import to use the 'native' svccfg.
-    sed 's/\/usr\/sbin\/svccfg/\$SVCCFG/g' \
+    # Transform manifest-import to use the 'native' svccfg.
+    sed 's^/usr/sbin/svccfg^$SVCCFG^g' \
         < ${ROOTDIR}/lib/svc/method/manifest-import \
         > /tmp/manifest-import.$$
     chmod 0755 /tmp/manifest-import.$$
@@ -300,13 +299,11 @@ step() {
         -d ${ROOTDIR}/lib/svc/manifest
     /bin/rm -f /tmp/manifest-import.$$
 
+    echo " --- neutering boot-archive"
     ${SVCCFG} -s 'system/boot-archive' setprop 'start/exec=:true'
-    ${SVCCFG} -s 'system/manifest-import' setprop 'start/exec=:true'
-    # system/intrd is discarded above
-    #${SVCCFG} -s "system/intrd:default" setprop "general/enabled=false"
-    ${SVCCFG} -s "system/initial-boot" setprop "start/timeout_seconds=3600"
 
     echo " --- neutering the manifest import"
+    ${SVCCFG} -s 'system/manifest-import' setprop 'start/exec=:true'
     echo "#!/bin/ksh" > ${ROOTDIR}/lib/svc/method/manifest-import
     echo "exit 0" >> ${ROOTDIR}/lib/svc/method/manifest-import
     chmod 555 ${ROOTDIR}/lib/svc/method/manifest-import
@@ -321,6 +318,9 @@ step() {
         /^LOCALE=/s^=.*^=/bin/who^
         s/is_C=0/is_C=1/
     ' ${ROOTDIR}/usr/bin/tzselect
+
+    echo " --- increasing initial-boot timeout"
+    ${SVCCFG} -s "system/initial-boot" setprop "start/timeout_seconds=86400"
 
     echo " --- updating root environment"
     cat << EOM > $ROOTDIR/root/.bashrc
@@ -345,7 +345,7 @@ EOM
             done
             rm -f "$ROOTDIR/$file"
         done < <(cd $ROOTDIR && find ./ | cut -c3-)
-        for path in $RMRF ; do
+        for path in $RMRF; do
             rm -rf ${ROOTDIR}$path && echo " --- discarding $path"
         done
     fi
@@ -425,4 +425,4 @@ while [ -n "$CHKPT" ]; do
 done
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/data/access.log
+++ b/data/access.log
@@ -1385,6 +1385,7 @@
 20862298 /var/mail
 20862298 /var/mail/:saved
 20862301 /root/.profile
+20862301 /root/.bashrc
 20862331 /usr/share/lib/terminfo
 20862331 /usr/share/lib/terminfo/d
 20862331 /usr/share/lib/terminfo/d/dumb

--- a/data/access.log
+++ b/data/access.log
@@ -381,6 +381,7 @@
 20506175 /lib/libmd.so.1
 20506177 /lib/libmp.so.2
 20506178 /lib/libsec.so.1
+20506178 /lib/amd64/libsec.so.1
 20506180 /usr/lib/libidmap.so.1
 20506180 /usr/lib/amd64/libidmap.so.1
 20506180 /usr/lib/libipmi.so.1

--- a/data/known_extras
+++ b/data/known_extras
@@ -57,6 +57,7 @@
 0 /usr/bin/pfiles
 0 /usr/bin/vi
 0 /usr/bin/vim
+0 /usr/bin/edit
 0 /usr/lib/libncurses.so.*
 0 /usr/lib/amd64/libncurses.so.*
 0 /usr/lib/lddstub
@@ -79,3 +80,4 @@
 0 /usr/bin/nc
 0 /usr/sbin/smbios
 0 /usr/bin/cpuid
+0 /usr/sbin/chroot

--- a/etc/noautofs.xml
+++ b/etc/noautofs.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='profile' name='site'
+	 xmlns:xi='http://www.w3.org/2003/XInclude' >
+  <service name='system/filesystem/autofs' version='1' type='service'>
+    <instance name='default' enabled='false'/>
+  </service>
+</service_bundle>

--- a/installer/config-menu
+++ b/installer/config-menu
@@ -781,12 +781,16 @@ load_user()
 	user_pfexec=
 	user_sudo=
 	user_sudo_nopw=
+	user_shell=
 	if [ -f $INITIALBOOT ]; then
 		user_uid=`grep useradd $INITIALBOOT | awk '{print $NF}'`
 		user_sudo=`grep groupadd $INITIALBOOT | cut -d\  -f2`
+		user_shell=`grep 'usermod -s' $INITIALBOOT | cut -d\  -f3`
 		egrep -s 'Primary Admin' $INITIALBOOT && user_pfexec=y
 		egrep -s 'NOPASSWD:' $INITIALBOOT && user_sudo_nopw=y
 	fi
+
+	[ -z "$user_shell" ] && user_shell=/bin/ksh
 }
 
 save_user()
@@ -798,6 +802,8 @@ save_user()
 		echo "mkdir -p /export/home"
 		echo "/usr/sbin/useradd -mZ -d /export/home/$user_uid $user_uid"
 		echo "/usr/sbin/usermod -d /home/$user_uid $user_uid"
+		[ -n "$user_shell" ] \
+		    && echo "/usr/sbin/usermod -s $user_shell $user_uid"
 		echo "echo '$user_uid localhost:/export/home/&'"\
 		    ">> /etc/auto_home"
 		hash=`$PASSUTIL -H "$user_pass"`
@@ -847,7 +853,7 @@ dcfg_user()
 			12 50 0 \
 			"        Username :"  1 1  "$user_uid"  1 22 20 0 0 \
 			"$plab"               2 1  ""           2 22 20 0 1 \
-			" Retype Password :"  3 1  ""           3 22 20 0 1 \
+			"Re-type Password :"  3 1  ""           3 22 20 0 1 \
 		    2> $tmpf
 		stat=$?
 		if [ $stat -eq 3 ]; then
@@ -883,6 +889,22 @@ dcfg_user()
 	done
 
 	if [ -n "$user_uid" ]; then
+		dialog \
+		    --title "Select shell" \
+		    --colors \
+		    --default-item $user_shell \
+		    --hline "If unsure, leave this at the default" \
+		    --radiolist "\nSelect the command line shell for the user\n\Zn" \
+			10 50 0 \
+			ksh "Ksh93 (Korn Shell)" on \
+			bash "Bash (Bourne-again Shell)" off \
+			csh "Csh (C Shell)" off \
+			2> $tmpf
+		stat=$?
+		[ $stat -ne 0 ] && return
+		user_shell="/bin/`cat $tmpf`"
+		rm -f $tmpf
+
 		dialog \
 		    --title "Creating user" \
 		    --colors \

--- a/installer/config-menu
+++ b/installer/config-menu
@@ -17,6 +17,7 @@
 #
 
 ALTROOT=/mnt
+RPOOL=`zpool list -H | nawk 'NR == 1 { print $1 }'`
 INITIALBOOT=$ALTROOT/.initialboot
 IPCALC=/kayak/bin/ipcalc
 PASSUTIL=/kayak/bin/passutil
@@ -798,14 +799,18 @@ save_user()
 	remove_config USER
 	[ -z "$user_uid" ] && return
 	(
+		# If creating a user from the installer, create a
+		# BE-independent filesystem for the home directory and do
+		# not use autofs.
+		[ -d $ALTROOT/etc/svc/profile/site ] \
+		    || mkdir -p $ALTROOT/etc/svc/profile/site
+		cp /kayak/etc/noautofs.xml $ALTROOT/etc/svc/profile/site/
 		echo '### BEGIN_USER'
-		echo "mkdir -p /export/home"
-		echo "/usr/sbin/useradd -mZ -d /export/home/$user_uid $user_uid"
-		echo "/usr/sbin/usermod -d /home/$user_uid $user_uid"
+		echo "/sbin/zfs create -o mountpoint=/home $RPOOL/home"
+		echo "chmod 0555 /home"		# as per SUNWcs
+		echo "/usr/sbin/useradd -mz -d /home/$user_uid $user_uid"
 		[ -n "$user_shell" ] \
 		    && echo "/usr/sbin/usermod -s $user_shell $user_uid"
-		echo "echo '$user_uid localhost:/export/home/&'"\
-		    ">> /etc/auto_home"
 		hash=`$PASSUTIL -H "$user_pass"`
 		echo "sed -i 's|^$user_uid:[^:]*|$user_uid:$hash|' /etc/shadow"
 		[ -n "$user_pfexec" ] && \
@@ -830,6 +835,8 @@ remove_user()
 {
 	user_uid=
 	remove_config USER
+	[ -f $ALTROOT/etc/svc/profile/site/noautofs.xml ] \
+	    && rm -f $ALTROOT/etc/svc/profile/site/noautofs.xml
 }
 
 dcfg_user()
@@ -1155,8 +1162,8 @@ cfg_sshd()
 	if [ -f $ALTROOT/etc/svc/profile/site/nossh.xml ]; then
 		rm -f $ALTROOT/etc/svc/profile/site/nossh.xml
 	else
-		[ -d  $ALTROOT/etc/svc/profile/site ] \
-		    || mkdir -p  $ALTROOT/etc/svc/profile/site
+		[ -d $ALTROOT/etc/svc/profile/site ] \
+		    || mkdir -p $ALTROOT/etc/svc/profile/site
 		cp /kayak/etc/nossh.xml $ALTROOT/etc/svc/profile/site/nossh.xml
 	fi
 }

--- a/installer/config-menu
+++ b/installer/config-menu
@@ -20,6 +20,7 @@ ALTROOT=/mnt
 INITIALBOOT=$ALTROOT/.initialboot
 IPCALC=/kayak/bin/ipcalc
 PASSUTIL=/kayak/bin/passutil
+NODENAME="`cat $ALTROOT/etc/nodename`"
 
 debug=0
 if [ "$1" = '-t' ]; then
@@ -181,11 +182,43 @@ remove_config()
 ##############################################################################
 # Networking
 
+reset_hosts()
+{
+	sed -i '/^[^#]/d' $ALTROOT/etc/inet/hosts
+	cat <<- EOM >> $ALTROOT/etc/inet/hosts
+::1		localhost $NODENAME.local $NODENAME
+127.0.0.1	localhost loghost $NODENAME.local $NODENAME
+	EOM
+}
+
+set_hosts()
+{
+	typeset ip=${net_ip%/*}
+	typeset domain="$net_domain"
+	[ -z "$domain" ] && domain=local
+
+	sed -i '/^[^#]/d' $ALTROOT/etc/inet/hosts
+	if [ "$net_ifmode" = "static" ]; then
+		cat <<- EOM >> $ALTROOT/etc/inet/hosts
+::1		localhost
+127.0.0.1	localhost loghost
+$ip	$NODENAME.$domain $NODENAME
+		EOM
+	else
+		cat <<- EOM >> $ALTROOT/etc/inet/hosts
+::1		localhost $NODENAME.$domain $NODENAME
+127.0.0.1	localhost loghost $NODENAME.$domain $NODENAME
+		EOM
+	fi
+}
+
 save_networking()
 {
 	remove_config NETWORK
+	reset_hosts
 	[ -n "$net_if" ] || return
 	[ "$net_ifmode" = "static" -a -z "$net_ip" ] && return
+	set_hosts
 	(
 		echo '### BEGIN_NETWORK'
 		echo "/sbin/ipadm create-if $net_if"

--- a/installer/dialog-install
+++ b/installer/dialog-install
@@ -295,7 +295,7 @@ case "$PSCHEME" in
 		# The zpool slice will now be slice 1 but slice 0 may have a
 		# pool label from a previous installation. Clear it out.
 		for disk in $DISKLIST; do
-			zpool labelclear -f ${disk}s0
+			zpool labelclear -f ${disk}s0 >/dev/null 2>&1
 		done
 		;;
 	MBR)
@@ -326,7 +326,7 @@ case $PSCHEME in
     GPT+Active)
 	zpool export $RPOOL >/dev/null 2>&1
 	for disk in $DISKLIST; do
-		# Set first entry in pMBR active
+		# Set first entry in PMBR active
 		fdisk -E 0:1 ${disk}p0
 	done
 	zpool import $pool_guid
@@ -335,7 +335,7 @@ case $PSCHEME in
     GPT+Slot1)
 	zpool export $RPOOL >/dev/null 2>&1
 	for disk in $DISKLIST; do
-		# Move first pMBR entry to slot 1
+		# Move first PMBR entry to slot 1
 		fdisk -E 1:0 ${disk}p0
 	done
 	zpool import $pool_guid

--- a/installer/dialog-install
+++ b/installer/dialog-install
@@ -357,7 +357,7 @@ prompt_hostname omniosce
 prompt_timezone
 
 ZFS_IMAGE=/.cdrom/image/*.zfs.bz2
-d_info "Installing from ZFS image $ZFS_IMAGE"
+d_info "Preparing to install..."
 
 # Because of kayak's small miniroot, just use C as the language for now.
 LANG=C

--- a/installer/kayak-menu
+++ b/installer/kayak-menu
@@ -27,7 +27,7 @@
 # OpenSolaris CDDL statement.
 
 # Block all signals which could terminate the menu or return to a parent
-# process
+# process, except if started with the '-t' option for testing.
 debug=0
 [ "$1" != '-t' ] && trap "" TSTP INT TERM ABRT QUIT || debug=1
 
@@ -275,7 +275,7 @@ while :; do
 	[ -n "${item.msg_str}" ] && printf "%s\n" "${item.msg_str}"
 
 	# Launch commands as a subprocess.
-	# However, launch the functions within the context 
+	# However, launch the functions within the context
 	# of the current process.
 	if [ "${item.do_subprocess}" = "true" ]; then
 		(

--- a/lib/install_help.sh
+++ b/lib/install_help.sh
@@ -268,10 +268,11 @@ SetHostname()
   log "Setting hostname: ${1}"
   /bin/hostname "$1"
   echo "$1" > $ALTROOT/etc/nodename
-  head -n 26 $ALTROOT/etc/hosts > /tmp/hosts
-  echo "::1\t\t$1" >> /tmp/hosts
-  echo "127.0.0.1\t$1" >> /tmp/hosts
-  cat /tmp/hosts > $ALTROOT/etc/hosts
+  sed -i '/^[^#]/d' $ALTROOT/etc/inet/hosts
+  cat << EOM >> $ALTROOT/etc/inet/hosts
+::1		localhost $1.local $1
+127.0.0.1	localhost loghost $1.local $1
+EOM
 }
 
 AutoHostname() {


### PR DESCRIPTION
This PR encompasses a number of enhancements/changes to Kayak as a result of installation experience, talking new users through tasks, and from feedback received. It's broken into separate commits to aid reviewing.

The main changes are:

* When creating a new user through the installer, disable the `autofs` system and create /home as a new BE-independent ZFS filesystem - this is different to the previous installer which put the real home directory under /export/home and configured autofs to mount it to /home. New users found this extremely confusing and /export was also tied to the BE, again causing confusion as files came and went along with switching BEs. If a user is not created through the installer configuration menu, then autofs remains enabled so for expert users (including those installing via PXE), there is no change;
* The `/etc/inet/hosts` file is now updated based on the networking configuration performed in the installer;
* Allow shell selection when creating a new user. This is limited to the shells that are part of the default installation.

Please test - https://downloads.omniosce.org/media/bloody/.swamp/omniosce-bloody-20180627.iso