### PR TITLE
Rename ZFS dataset used for miniroot, "root" -> "miniroot"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,22 +52,22 @@ $(DESTDIR)/tftpboot/boot/grub/menu.lst:	sample/menu.lst.000000000000
 
 # Files from proto
 
-$(DESTDIR)/tftpboot/pxegrub:	$(BUILDSEND_MP)/root/boot/grub/pxegrub
+$(DESTDIR)/tftpboot/pxegrub:	$(BUILDSEND_MP)/miniroot/boot/grub/pxegrub
 	cp -p $< $@
 
-$(DESTDIR)/tftpboot/pxeboot:	$(BUILDSEND_MP)/root/boot/pxeboot
+$(DESTDIR)/tftpboot/pxeboot:	$(BUILDSEND_MP)/miniroot/boot/pxeboot
 	cp -p $< $@
 
-$(DESTDIR)/tftpboot/boot/loader.rc:	$(BUILDSEND_MP)/root/boot/loader.rc
+$(DESTDIR)/tftpboot/boot/loader.rc:	$(BUILDSEND_MP)/miniroot/boot/loader.rc
 	cp -p $< $@
 
-$(DESTDIR)/tftpboot/boot/forth:	$(BUILDSEND_MP)/root/boot/forth
+$(DESTDIR)/tftpboot/boot/forth:	$(BUILDSEND_MP)/miniroot/boot/forth
 	cp -rp $< $@
 
-$(DESTDIR)/tftpboot/boot/defaults:	$(BUILDSEND_MP)/root/boot/defaults
+$(DESTDIR)/tftpboot/boot/defaults:	$(BUILDSEND_MP)/miniroot/boot/defaults
 	cp -rp $< $@
 
-$(DESTDIR)/tftpboot/boot/platform/i86pc/kernel/amd64/unix:	$(BUILDSEND_MP)/root/platform/i86pc/kernel/amd64/unix
+$(DESTDIR)/tftpboot/boot/platform/i86pc/kernel/amd64/unix:	$(BUILDSEND_MP)/miniroot/platform/i86pc/kernel/amd64/unix
 	cp -p $< $@
 
 $(DESTDIR)/var/kayak/kayak/$(VERSION).zfs.bz2:	$(BUILDSEND_MP)/kayak_$(VERSION).zfs.bz2
@@ -87,7 +87,7 @@ $(BUILDSEND_MP)/kayak_$(VERSION).zfs.bz2:	build/build_zfs_send
 	./$< -d $(BUILDSEND) $(VERSION)
 
 $(BUILDSEND_MP)/miniroot.gz:	build/build_miniroot
-	if test -n "`zfs list -H -t snapshot $(BUILDSEND)/root@fixup 2>/dev/null`"; then \
+	if test -n "`zfs list -H -t snapshot $(BUILDSEND)/miniroot@fixup 2>/dev/null`"; then \
 	  VERSION=$(VERSION) DEBUG=$(DEBUG) ./$< $(BUILDSEND) fixup ; \
 	else \
 	  VERSION=$(VERSION) DEBUG=$(DEBUG) ./$< $(BUILDSEND) begin ; \

--- a/build/build_miniroot
+++ b/build/build_miniroot
@@ -42,10 +42,11 @@ else
     BASEDIR=`zfs get -o value -H mountpoint $BASE`
 fi
 MKFILEDIR=/tmp
+DATASET=miniroot
 WORKDIR=$BASEDIR
-ROOTDIR=$WORKDIR/root
+ROOTDIR=$WORKDIR/$DATASET
 if [ ! -d "$ROOTDIR" ]; then
-    zfs create -o compression=off $BASE/root || fail "zfs create failed"
+    zfs create -o compression=off $BASE/$DATASET || fail "zfs create failed"
 fi
 SVCCFG_DTD=${ROOTDIR}/usr/share/lib/xml/dtd/service_bundle.dtd.1
 SVCCFG_REPOSITORY=${ROOTDIR}/etc/svc/repository.db
@@ -194,16 +195,16 @@ if [ "$ID" != "0" ]; then
 fi
 
 chkpt() {
-    SNAP=`zfs list -H -t snapshot $BASE/root@$1 2> /dev/null`
+    SNAP=`zfs list -H -t snapshot $BASE/$DATASET@$1 2> /dev/null`
     if [ "$DIDWORK" -ne "0" ]; then
         if [ -n "$SNAP" ]; then
-            zfs destroy $BASE/root@$1 || fail "zfs destroy $1 failed"
+            zfs destroy $BASE/$DATASET@$1 || fail "zfs destroy $1 failed"
         fi
-        zfs snapshot $BASE/root@$1 || fail "zfs snapshot failed"
+        zfs snapshot $BASE/$DATASET@$1 || fail "zfs snapshot failed"
     fi
     if [ "$1" != "begin" ]; then
         echo " === Proceeding to phase $1 (zfs @$1) ==="
-        zfs rollback -r $BASE/root@$1 || fail "zfs rollback failed"
+        zfs rollback -r $BASE/$DATASET@$1 || fail "zfs rollback failed"
     else
         echo " === Proceeding to phase $1 ==="
     fi
@@ -241,8 +242,8 @@ step() {
     case "$1" in
 
   "begin")
-    zfs destroy -r $BASE/root 2> /dev/null
-    zfs create -o compression=off $BASE/root || fail "zfs create failed"
+    zfs destroy -r $BASE/$DATASET 2> /dev/null
+    zfs create -o compression=off $BASE/$DATASET || fail "zfs create failed"
     chkpt pkg
     ;;
 
@@ -356,7 +357,7 @@ EOM
 
   "mkfs")
     size=`/usr/bin/du -ks ${ROOTDIR} | /usr/bin/nawk '{print $1+10240}'`
-    echo " --- making image of size $size"
+    echo " --- making image of size ${size}k"
     /usr/sbin/mkfile ${size}k $MKFILEDIR/miniroot || fail "mkfile"
     lofidev=`/usr/sbin/lofiadm -a $MKFILEDIR/miniroot`
     rlofidev=`echo $lofidev |sed s/lofi/rlofi/`


### PR DESCRIPTION
Calling it "root" is confusing as it is not clear whether this is the miniroot or the ZFS stream root.