### PR TITLE
Include psrinfo in miniroot

### DIFF
--- a/data/known_extras
+++ b/data/known_extras
@@ -81,3 +81,4 @@
 0 /usr/sbin/smbios
 0 /usr/bin/cpuid
 0 /usr/sbin/chroot
+0 /usr/sbin/psrinfo


### PR DESCRIPTION
The supporting libraries are already present, this adds just 14KiB.