### PR TITLE
Use parallel xzip compression...

### DIFF
--- a/build/build_iso
+++ b/build/build_iso
@@ -49,7 +49,7 @@ stage()
 
 # Files prepared by other parts of the kayak build process
 
-KAYAK_MINIROOT=$BUILDSEND_MP/miniroot.gz
+KAYAK_MINIROOT=$BUILDSEND_MP/miniroot.ufs
 ZFS_IMG=$BUILDSEND_MP/kayak_${VERSION}.zfs.xz
 
 [ ! -f $KAYAK_MINIROOT -o ! -f $ZFS_IMG ] && echo "Missing files." && exit 1
@@ -95,7 +95,7 @@ set -o errexit
 # $MINIROOT_ROOT
 
 stage "Mounting source miniroot"
-$GZIP_CMD -dc $KAYAK_MINIROOT > $MINIROOT_FILE
+cp $KAYAK_MINIROOT $MINIROOT_FILE
 LOFI_MINIROOT=`lofiadm -a $MINIROOT_FILE`
 mkdir $MINIROOT_ROOT
 mount $LOFI_MINIROOT $MINIROOT_ROOT

--- a/build/build_miniroot
+++ b/build/build_miniroot
@@ -424,8 +424,8 @@ EOM
     ;;
 
   "compress")
-    $GZIP_CMD -9c -f $MKFILEDIR/miniroot > $WORKDIR/miniroot.gz
-    rm -f $MKFILEDIR/miniroot
+    mv $MKFILEDIR/miniroot $WORKDIR/miniroot.ufs
+    $GZIP_CMD -9c -f $WORKDIR/miniroot.ufs > $WORKDIR/miniroot.gz
     chmod 644 $WORKDIR/miniroot.gz
     echo " === Finished ==="
     $GZIP_CMD -l $WORKDIR/miniroot.gz

--- a/build/build_zfs_send
+++ b/build/build_zfs_send
@@ -169,7 +169,8 @@ fi
 
 note "Creating compressed stream"
 zfs snapshot $ZROOT/$name@kayak || fail "snap"
-zfs send $ZROOT/$name@kayak | pv | xz -9c > $OUT || fail "send/compress"
+zfs send $ZROOT/$name@kayak | pv | xz -T0 -9c > $OUT || fail "send/compress"
+xz -l $OUT
 
 ############################################################################
 

--- a/data/boot
+++ b/data/boot
@@ -39,6 +39,7 @@
 0 /boot/acpi/tables
 0 /boot/solaris
 0 /boot/illumos.png
+0 /boot/illumos-small.png
 0 /boot/ooce.png
 0 /boot/dragon.png
 0 /boot/dragonf.png


### PR DESCRIPTION
... and do not needlessly uncompress the miniroot.

The parallel compression gives a five fold speed improvement on my test VM with only a very small size increase (due to the fixed block size that parallelism enforces):

```
xz -9c raw > /dev/null  577.37s user 3.42s system 99% cpu 9:40.98 total
xz -9c raw > /dev/null  651.35s user 3.50s system 99% cpu 10:55.11 total

xz -T0 -9c raw > /dev/null  704.48s user 10.36s system 523% cpu 2:16.44 total
xz -T0 -9c raw > /dev/null  669.92s user 9.29s system 512% cpu 2:12.55 total

bloody# xz -l kayak_r151029.zfs.xz test.xz
Strms  Blocks   Compressed Uncompressed  Ratio  Check   Filename
    1       1    178.8 MiB   1108.0 MiB  0.161  CRC64   kayak_r151029.zfs.xz
    1       6    180.4 MiB   1108.0 MiB  0.163  CRC64   parallel-kayak_r151029.zfs.xz
```