### PR TITLE
Remove lofiadm workaround

### DIFF
--- a/build/build_iso
+++ b/build/build_iso
@@ -288,14 +288,8 @@ if [ -n "$UEFI_SIZE" ]; then
 
 	stage "Converting ISO to hybrid image"
 
-	set +e
-	LOFI_ISO=`lofiadm -la $DST_ISO 2>/dev/null`
-	sleep 1
-	lofiadm -d $DST_ISO
-	sleep 1
 	LOFI_ISO=`lofiadm -la $DST_ISO`
 	[ -n "$LOFI_ISO" ] || exit 1
-	set -e
 
 	RLOFI_ISO=${LOFI_ISO/dsk/rdsk}
 	P2LOFI_ISO=${RLOFI_ISO/p0/p2}


### PR DESCRIPTION
Recent fixes to lofiadm mean that we can remove this workaround now.