### PR TITLE
less now depends on pcre

### DIFF
--- a/data/known_extras
+++ b/data/known_extras
@@ -32,6 +32,7 @@
 0 /usr/lib/utmpd
 0 /lib/libintl.so.1
 0 /usr/bin/less
+0 /usr/lib/amd64/libpcre2-8.so.*
 0 /usr/bin/more
 0 /usr/lib/libgss.so.1
 0 /lib/libcrypto.so.*


### PR DESCRIPTION
The update of [less to version 551](https://github.com/omniosorg/omnios-build/commit/c87b59e6b4ce31191a966101f197ef69d9c69d63) appears to have introduced a dependency on `libpcre`.  This causes a failure in the `kayak-kernel` build:

```
...
 === Proceeding to phase sanity (zfs @sanity) ===
--- /ws/stock/tmp/kayak-kernel-1.1/kayak-kernel-1.1/kayak/./build/../data/baseline      Sat Aug 24 23:57:01 2019
+++ /tmp/tmp.Inai41     Sun Aug 25 00:02:07 2019
@@ -13,0 +13,1 @@
+Missing library usr/bin/less requires /usr/lib/64/libpcre2-8.so.0
```

This change adds `libpcre2-8.so.*` to the list of files to ship in the install image.