### PR TITLE
Build (most) installer binaries as 32-bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,13 +144,13 @@ BINS=bin/takeover-console bin/ipcalc bin/dialog bin/passutil bin/mount_media \
 	 etc/kbd.list bin/zpool_patch
 
 bin/takeover-console:	src/takeover-console.c
-	gcc -o $@ $<
+	gcc -m32 -o $@ $<
 
 bin/passutil:	src/passutil.c
-	gcc -o $@ $<
+	gcc -m32 -o $@ $<
 
 bin/mount_media:	src/mount_media.c
-	gcc -o $@ $< -ldevinfo
+	gcc -m32 -o $@ $< -ldevinfo
 
 bin/zpool_patch:	src/zpool_patch.c
 	gcc -m64 -g -Wall -Wunused -g -Isrc/include -o $@ $< -lnvpair

--- a/build/build_dialog
+++ b/build/build_dialog
@@ -27,7 +27,7 @@ dir=`/usr/gnu/bin/mktemp -d`
 	wget $URL
 	gtar -zxf $FILE
 	cd $PROG-$VER
-	./configure
+	./configure CFLAGS=-m32
 	gmake
 )
 

--- a/build/build_ipcalc
+++ b/build/build_ipcalc
@@ -25,7 +25,7 @@ dir=`/usr/gnu/bin/mktemp -d`
 		LIBS="-lsocket -lnsl -lresolv" \
 		USE_GEOIP=no \
 		USE_DYN_GEOIP=no \
-		CFLAGS=-D_KERNEL
+		CFLAGS="-m32 -D_KERNEL"
 )
 
 cp $dir/$PROG-$VER/$PROG ./bin/$PROG


### PR DESCRIPTION
In some cases, the installer does not contain the required libraries as
64-bit objects.