### PR TITLE
Revert "add libtermcap"

### DIFF
--- a/data/lib
+++ b/data/lib
@@ -28,7 +28,6 @@
 /lib/amd64/libsocket.so.1
 /lib/amd64/libssl.so.1.1
 /lib/amd64/libsysevent.so.1
-/lib/amd64/libtermcap.so.1
 /lib/amd64/libumem.so.1
 /lib/amd64/libuutil.so.1
 /lib/amd64/libz.so


### PR DESCRIPTION
This reverts commit a13d7e2cdda32e328d7d102e5d5ea684db55310c.

This is no longer required since the changes to readline were also reverted.
