### PR TITLE
Add libbrotlidec.so to miniroot

### DIFF
--- a/data/lib
+++ b/data/lib
@@ -189,6 +189,8 @@
 /usr/lib/amd64
 /usr/lib/amd64/ld.so.1
 /usr/lib/amd64/libast.so.1
+/usr/lib/amd64/libbrotlicommon.so.*
+/usr/lib/amd64/libbrotlidec.so.*
 /usr/lib/amd64/libc.so.1
 /usr/lib/amd64/libcmd.so.1
 /usr/lib/amd64/libcrypto.so.*


### PR DESCRIPTION
Curl recently acquired brotli support. It now needs the appropriate libraries in the miniroot.