### PR TITLE
Using full path to dladm in Ether()

### DIFF
--- a/installer/install-image
+++ b/installer/install-image
@@ -26,6 +26,8 @@
 #
 
 . /kayak/lib/install_help.sh
+
+FailIfRpoolExists
 ConsoleLog /tmp/kayak.log
 ForceDHCP
 RunInstall || bomb "RunInstall failed."

--- a/lib/install_help.sh
+++ b/lib/install_help.sh
@@ -30,6 +30,17 @@ SetupLog() {
     exec 4>>$INSTALL_LOG
 }
 
+# Check to see if this system has an rpool. We want to guard against install
+# over an already configured system should it accidentally PXE boot.
+FailIfRpoolExists() {
+    zpool import -a
+    res=`zpool list | grep rpool`
+
+    if [[ "$?" -eq "0" ]]; then
+        bomb "This is an installed system. To reinstall, destroy rpool and reboot."
+    fi
+}
+
 # Set up logging so that log messages go to the console and that stdout/stderr
 # go to a log file at the provided path.
 ConsoleLog() {

--- a/lib/net_help.sh
+++ b/lib/net_help.sh
@@ -19,7 +19,7 @@
 # Returns a mac address as 12 hex characters, upper-case, from the first
 # non-loopback interface in the system.
 Ether() {
-    local mac="`dladm show-phys -m -p -o ADDRESS | \
+    local mac="`/sbin/dladm show-phys -m -p -o ADDRESS | \
         /bin/tr '[:lower:]' '[:upper:]' | \
         sed '
             s/^/ 0/g


### PR DESCRIPTION
FetchConfig() fails because Ether() fails as dladm is not found in PATH (which
does not include /sbin).