### PR TITLE
Using full path to dladm in Ether()

### DIFF
--- a/lib/net_help.sh
+++ b/lib/net_help.sh
@@ -19,7 +19,7 @@
 # Returns a mac address as 12 hex characters, upper-case, from the first
 # non-loopback interface in the system.
 Ether() {
-    local mac="`dladm show-phys -m -p -o ADDRESS | \
+    local mac="`/sbin/dladm show-phys -m -p -o ADDRESS | \
         /bin/tr '[:lower:]' '[:upper:]' | \
         sed '
             s/^/ 0/g


### PR DESCRIPTION
FetchConfig() fails because Ether() fails as dladm is not found in PATH (which
does not include /sbin).