### PR TITLE
Ensure bash is in miniroot

### DIFF
--- a/build/build_miniroot
+++ b/build/build_miniroot
@@ -177,7 +177,7 @@ DRIVERS="driver/audio driver/crypto/dca driver/crypto/tpm driver/firewire
 
 PARTS="release/name release/notices service/picl install/beadm SUNWcs SUNWcsd
     library/libidn shell/pipe-viewer text/less editor/vim web/curl
-    developer/linker file/gnu-coreutils system/xopen/xcu4
+    developer/linker file/gnu-coreutils system/xopen/xcu4 shell/bash
     openssh openssh-server diagnostic/diskinfo network/netcat system/cpuid"
 
 PKGS="$PARTS $SYSTEM $DRIVERS"

--- a/data/baseline
+++ b/data/baseline
@@ -97,7 +97,6 @@ Unused library usr/lib/mdb/kvm/amd64/xhci.so
 Unused library usr/lib/mdb/proc/amd64/ld.so
 Unused library usr/lib/mdb/proc/amd64/libavl.so
 Unused library usr/lib/mdb/proc/amd64/libc.so
-Unused library usr/lib/mdb/proc/amd64/libcmdutils.so
 Unused library usr/lib/mdb/proc/amd64/libnvpair.so
 Unused library usr/lib/mdb/proc/amd64/libproc.so
 Unused library usr/lib/mdb/proc/amd64/libpython2.7.so


### PR DESCRIPTION
Some recent work to remove unnecessary dependencies on bash means that it is no longer implicitly installed in the miniroot. Since kayak runs user-supplied bash scripts and we use it for the interactive shell, install it implicitly.