### PR TITLE
Preserve autofs manifest to satisfy dependencies

### DIFF
--- a/data/miniroot.services
+++ b/data/miniroot.services
@@ -14,6 +14,7 @@ system/device/devices-local.xml
 system/device/mpxio-upgrade.xml
 system/early-manifest-import.xml
 system/fcoe_target.xml
+system/filesystem/autofs.xml
 system/filesystem/local-fs.xml
 system/filesystem/minimal-fs.xml
 system/filesystem/root-fs.xml


### PR DESCRIPTION
Fixes (harmless) errors during installation:

```
Please enter a number [1]: 4
Halting system, please wait...
SMF Initialization problems..svc:/system/filesystem/autofs
SMF Initialization problems..svc:/system/filesystem/autofs
SMF Initialization problems..svc:/system/filesystem/autofs
SMF Initialization problems..svc:/system/filesystem/autofs
SMF Initialization problems..svc:/system/filesystem/autofs
SMF Initialization problems..svc:/system/filesystem/autofs
AUTOFS plugin problem with SMF properties: unknown -1
```