### PR TITLE
fix building mount_media

### DIFF
--- a/src/mount_media.c
+++ b/src/mount_media.c
@@ -251,6 +251,7 @@ mount_minor(di_node_t node, di_minor_t minor, void *arg)
 {
 	char mpath[PATH_MAX];
 	char *volid = arg;
+	char *cp;
 
 	char *driver = di_driver_name(node);
 	char *nodetype = di_minor_nodetype(minor);
@@ -327,7 +328,7 @@ mount_minor(di_node_t node, di_minor_t minor, void *arg)
 
 mount:
 	/* Remove raw suffix from path to get to block device for mount */
-	char *cp = strstr(mpath, ",raw");
+	cp = strstr(mpath, ",raw");
 	if (cp != NULL)
 		*cp = '\0';
 	if (mount_image(mpath, volid) == 0) {


### PR DESCRIPTION
Not sure if (and why) it works when building omnios, for me all compilers I have tried are not happy, e.g.:
```
gcc -m32 -std=gnu99 -o bin/mount_media src/mount_media.c -ldevinfo
src/mount_media.c: In function 'mount_minor':
src/mount_media.c:330:2: error: a label can only be part of a statement and a declaration is not a statement
  330 |  char *cp = strstr(mpath, ",raw");
      |  ^~~~
gmake: *** [Makefile:153: bin/mount_media] Error 1
```

Fix by moving declaration above the label.