### PR TITLE
increase UEFI_SIZE to 4400K

### DIFF
--- a/build/iso
+++ b/build/iso
@@ -75,7 +75,7 @@ typeset -i basz=225
 BA_SIZE=${basz}M
 
 # Comment the following line out to build a CSM-only ISO.
-UEFI_SIZE=4M
+UEFI_SIZE=4400K
 
 # Output file
 


### PR DESCRIPTION
This makes it match the size=8800 passed to mkfs below and gets rid of the following warning in the log:

    pcfs: WARNING: pcfs: autodetected mediasize (4194304 Bytes) smaller than
    FAT BPB mediasize (4505600 Bytes).