### PR TITLE
miniroot needs new lmrc driver

### DIFF
--- a/data/keep.kernel
+++ b/data/keep.kernel
@@ -122,6 +122,7 @@
 /kernel/drv/amd64/keysock
 /kernel/drv/amd64/kmdb
 /kernel/drv/amd64/llc1
+/kernel/drv/amd64/lmrc
 /kernel/drv/amd64/lofi
 /kernel/drv/amd64/log
 /kernel/drv/amd64/lsimega
@@ -296,6 +297,7 @@
 /kernel/drv/keysock.conf
 /kernel/drv/kmdb.conf
 /kernel/drv/llc1.conf
+/kernel/drv/lmrc.conf
 /kernel/drv/lofi.conf
 /kernel/drv/log.conf
 /kernel/drv/lsimega.conf

--- a/data/miniroot.pkglist
+++ b/data/miniroot.pkglist
@@ -89,6 +89,7 @@ driver/storage/bcm_sata
 driver/storage/blkdev
 driver/storage/cpqary3
 driver/storage/glm
+driver/storage/lmrc
 driver/storage/lsimega
 driver/storage/marvell88sx
 driver/storage/mega_sas


### PR DESCRIPTION
Teaches Kayak to add the new `drivers/storage/lmrc` package and retains its driver object and `.conf` files.