### PR TITLE
Be explicit about which pcre2 ABI library to retain in the miniroot

### DIFF
--- a/data/keep.lib
+++ b/data/keep.lib
@@ -231,7 +231,7 @@
 /usr/lib/amd64/libnvpair.so.1
 /usr/lib/amd64/libpcidb.so.1
 /usr/lib/amd64/libpcre2-8.so.0
-/usr/lib/amd64/libpcre2-8.so.0.*
+/usr/lib/amd64/libpcre2-8.so.0.11.*
 /usr/lib/amd64/libpool.so.1
 /usr/lib/amd64/libproject.so.1
 /usr/lib/amd64/libpsl.so.*


### PR DESCRIPTION
Fixes miniroot build error:
```
Unused library usr/lib/amd64/libpcre2-8.so.0.10.4
```

I ran a miniroot build with this change and it went through.