### PR TITLE
libnvme.so.1 is needed after 16171

### DIFF
--- a/data/keep.lib
+++ b/data/keep.lib
@@ -227,6 +227,7 @@
 /usr/lib/amd64/libncurses.so.6*
 /usr/lib/amd64/libnghttp2.so.*
 /usr/lib/amd64/libnsl.so.1
+/usr/lib/amd64/libnvme.so.1
 /usr/lib/amd64/libnvpair.so
 /usr/lib/amd64/libnvpair.so.1
 /usr/lib/amd64/libpcidb.so.1


### PR DESCRIPTION
See https://buildbot.omnios.org/#/builders/1/builds/13