### PR TITLE
Map PCI aliases to the newer `smrt` driver versus `cpqary3`

### DIFF
--- a/build/miniroot
+++ b/build/miniroot
@@ -52,6 +52,7 @@ MKFILEDIR=/tmp
 DATASET=miniroot
 WORKDIR=$BASEDIR
 ROOTDIR=$WORKDIR/$DATASET
+ARCH=`uname -p`
 
 : ${PKGURL:=$OOCEPUBURL}
 export PKG_IMAGE=$ROOTDIR
@@ -143,11 +144,18 @@ function step_pkg {
     fi
 
     echo "Creating image of $OOCEPUB from $PKGURL"
-    pkg image-create -F -p $OOCEPUB=$PKGURL $ROOTDIR || fail "image-create"
+
+    typeset args=
+    args+="--variant arch=$ARCH "
+    # Map PCI aliases to the newer `smrt` driver versus `cpqary3`
+    args+="--variant smrt.aliases=true "
     # No need to install documentation or development files in the miniroot
-    pkg change-facet doc.man=false
-    pkg change-facet devel=false
-    [ -n "$DEBUG_VARIANT" ] && pkg change-variant debug.illumos=true
+    args+="--facet doc.man=false "
+    args+="--facet devel=false "
+    [ -n "$DEBUG_VARIANT" ] && args+="--variant debug.illumos=true "
+
+    pkg image-create --full --publisher $OOCEPUB=$PKGURL $args $ROOTDIR \
+        || fail "image-create"
     pkg install ${pkglist[@]} || fail "install"
 
     chkpt fixup

--- a/build/zfs_send
+++ b/build/zfs_send
@@ -136,12 +136,14 @@ else
     zfs create $ZDATASET || fail "zfs create"
     MP=`zfs get -o value -H mountpoint $ZDATASET`
     [ -n "$MP" -a -d "$MP" ] || fail "$MP is not a directory"
-    args=
-    args+="--variant variant.arch=$ARCH "
+    typeset args=
+    args+="--variant arch=$ARCH "
+    # Map PCI aliases to the newer `smrt` driver versus `cpqary3`
+    args+="--variant smrt.aliases=true "
     [ -n "$DEBUG_VARIANT" ] && args+="--variant debug.illumos=true "
     note "Creating IPS image"
-    pkg image-create --full $args \
-        --publisher $OOCEPUB=$PKGURL $MP || fail "image-create"
+    pkg image-create --full --publisher $OOCEPUB=$PKGURL $args $MP \
+        || fail "image-create"
     export PKG_IMAGE=$MP
     if ((INSTALL_ENTIRE)); then
         note "Installing $entire_fmri"


### PR DESCRIPTION
This depends on [illumos 16718](https://www.illumos.org/issues/16718)