### PR TITLE
Makefile: add ability to send args for zfs_send command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ TFTP_FILES=\
 
 GZ_ZFS_STREAM=$(DESTDIR)/var/kayak/kayak/$(VERSION).zfs.xz
 NGZ_ZFS_STREAM=$(DESTDIR)/var/kayak/kayak/$(VERSION).ngz.zfs.xz
+ZFS_SEND_ARGS?=
 
 $(DESTDIR)/tftpboot/boot/loader.conf.local:	etc/loader.conf.local
 	sed -e 's/@VERSION@/$(VERSION)/' $< > $@
@@ -79,17 +80,17 @@ $(DESTDIR)/tftpboot/kayak/miniroot.gz.hash:	$(BUILDSEND_MP)/miniroot.gz
 $(BUILDSEND_MP)/kayak_$(VERSION).zfs.xz:	build/zfs_send
 	@banner "ZFS GZ IMG"
 	@test -d "$(BUILDSEND_MP)" || (echo "$(BUILDSEND) missing" && false)
-	./$< -d $(BUILDSEND) $(VERSION)
+	./$< -d $(BUILDSEND) $(ZFS_SEND_ARGS) $(VERSION)
 
 $(BUILDSEND_MP)/kayak_$(VERSION).ngz.zfs.xz:	build/zfs_send
 	@banner "ZFS NGZ IMG"
 	@test -d "$(BUILDSEND_MP)" || (echo "$(BUILDSEND) missing" && false)
-	./$< -d $(BUILDSEND) -V nonglobal $(VERSION)
+	./$< -d $(BUILDSEND) -V nonglobal $(ZFS_SEND_ARGS) $(VERSION)
 
 $(BUILDSEND_MP)/aarch64_$(VERSION).zfs.xz:	build/zfs_send
 	@banner "AARCH64 IMG"
 	@test -d "$(BUILDSEND_MP)" || (echo "$(BUILDSEND) missing" && false)
-	./$< -d $(BUILDSEND) -a aarch64 $(VERSION)
+	./$< -d $(BUILDSEND) -a aarch64 $(ZFS_SEND_ARGS) $(VERSION)
 
 $(BUILDSEND_MP)/miniroot.gz:	build/miniroot
 	@banner "MINIROOT"


### PR DESCRIPTION
build/zfs_send script contains various input parameters and flags. Currently, the kayak Makefile doesn't provide the ability to pass an argument when calling build/zfs_send target.

This patch adds the ability to send arguments using ZFS_SEND_ARGS variable. For example, now you can pass an additional list of packages (-p argument) for the resulting image as follows:

`gmake install-iso ZFS_SEND_ARGS="-p /path/to/packages.list"`