### PR TITLE
Fix custom overlay parameters

### DIFF
--- a/build/miniroot
+++ b/build/miniroot
@@ -423,7 +423,7 @@ function step_copy {
         cp $KYKDIR/etc/anon.dtrace.conf $WORKDIR/mnt/kernel/drv/dtrace.conf
     fi
 
-    apply_custom_overlay $MINIROOT_CUSTOM_OVERLAY $WORKDIR/mnt
+    apply_custom_overlay "$MINIROOT_CUSTOM_OVERLAY" "$WORKDIR/mnt"
 
     chkpt umount
 }

--- a/build/zfs_send
+++ b/build/zfs_send
@@ -267,7 +267,7 @@ if [ "$VARIANT" = nonglobal ]; then
     sed -i -e 's%^root::%root:$5$kr1VgdIt$OUiUAyZCDogH/uaxH71rMeQxvpDEY2yX.x0ZQRnmeb9:%' $MP/etc/shadow
 fi
 
-apply_custom_overlay $ZFS_CUSTOM_OVERLAY $MP
+apply_custom_overlay "$ZFS_CUSTOM_OVERLAY" "$MP"
 
 note "Creating compressed stream"
 zfs snapshot $ZDATASET@kayak || fail "snap"


### PR DESCRIPTION

Without this change one sees an error when the overlay variable is not
set as the first argument to the function is omitted.

```
 --- applying custom overlay from /kayak_image/r151057
cpio: Error during access() of "", errno 2, No such file or directory
USAGE:
        cpio -i[bcdfkmqrstuv@BSV6] [-C size] [-E file] [-H hdr] [-I file [-M
msg]] [-R id] [patterns]
        cpio -o[acv@ABLV] [-C size] [-H hdr] [-O file [-M msg]]
        cpio -p[adlmuv@LV] [-R id] directory
 WARNING: Failed to apply overlay completely
```
