### PR TITLE
zfs_send: batch profile package installs into a single pkg install call

### DIFF
--- a/build/zfs_send
+++ b/build/zfs_send
@@ -181,6 +181,7 @@ fi
 if [ -n "$PROFILE" ]; then
     note "Applying custom profile: $PROFILE"
     [ -r "$PROFILE" ] || fail "Cannot find file: $PROFILE"
+    typeset -a profile_pkgs=()
     while read line; do
         TMPPUB=`echo $line | cut -f1 -d=`
         TMPURL=`echo $line | cut -f2 -d=`
@@ -191,10 +192,14 @@ if [ -n "$PROFILE" ]; then
             OOCEPUB=$TMPPUB
             PKGURL=$TMPURL
         else
-            note "Installing additional package: $line"
-            pkg install -g $PKGURL $line || fail "install $line"
+            profile_pkgs+=($line)
         fi
     done < <(grep . $PROFILE | grep -v '^ *#')
+    if [ ${#profile_pkgs[@]} -gt 0 ]; then
+        note "Installing ${#profile_pkgs[@]} additional packages"
+        pkg install -g $PKGURL ${profile_pkgs[@]} \
+            || fail "install profile packages"
+    fi
 fi
 
 # Starting with r151014, require signatures for the omnios publishers.


### PR DESCRIPTION
Instead of invoking `pkg install` separately for each package in the profile, collect all package names into an array and install them in one operation. This avoids repeated dependency resolution and planning cycles, significantly reducing image build time for profiles with many packages.

Publisher lines are still processed individually before installation so that all sources are configured ahead of the batch install.