### PR TITLE
install_help: add BEName() to allow configuring the boot environment name

### DIFF
--- a/installer/dialog-install
+++ b/installer/dialog-install
@@ -25,6 +25,7 @@
 . /kayak/lib/disk_help.sh
 
 SetupLog /tmp/kayak.log
+BEName $BENAME
 
 keyboard_layout=${1:-US-English}
 
@@ -411,9 +412,11 @@ d_info "Preparing to install..."
 # Because of kayak's small miniroot, just use C as the language for now.
 LANG=C
 
-bename=omnios
-ver=`head -1 /etc/release | awk '{print $3}'`
-[ -n "$ver" ] && bename+="-$ver"
+bename=$BENAME
+if [ -z "$BENAME_SET" ]; then
+    ver=`head -1 /etc/release | awk '{print $3}'`
+    [ -n "$ver" ] && bename+="-$ver"
+fi
 
 BuildBE $RPOOL $ZFS_IMAGE $bename
 ApplyChanges $HOSTNAME $TZ $LANG $keyboard_layout \

--- a/installer/rpool-install
+++ b/installer/rpool-install
@@ -40,6 +40,7 @@ echo "Installing from ZFS image $ZFS_IMAGE"
 . /kayak/lib/install_help.sh
 
 SetupLog /tmp/kayak.log
+BEName $BENAME
 
 prompt_hostname omnios
 prompt_timezone
@@ -47,9 +48,11 @@ prompt_timezone
 # Because of kayak's small miniroot, just use C as the language for now.
 LANG=C
 
-bename=omnios
-ver=`head -1 /etc/release | awk '{print $3}'`
-[ -n "$ver" ] && bename+="-$ver"
+bename=$BENAME
+if [ -z "$BENAME_SET" ]; then
+    ver=`head -1 /etc/release | awk '{print $3}'`
+    [ -n "$ver" ] && bename+="-$ver"
+fi
 
 BuildBE $RPOOL $ZFS_IMAGE $bename
 ApplyChanges $HOSTNAME $TZ $LANG $keyboard_layout

--- a/lib/install_help.sh
+++ b/lib/install_help.sh
@@ -125,6 +125,14 @@ function getvar {
     prtconf -v /devices | sed -n '/'$1'/{;n;p;}' | cut -f2 -d\' | pipelog
 }
 
+BENAME=${BENAME:-omnios}
+BENAME_SET=
+function BEName {
+    log "Setting boot environment name to $1"
+    BENAME="$1"
+    BENAME_SET=1
+}
+
 # Blank
 ROOTPW='$5$kr1VgdIt$OUiUAyZCDogH/uaxH71rMeQxvpDEY2yX.x0ZQRnmeb9'
 function RootPW {
@@ -238,7 +246,7 @@ function BE_LinkMsglog {
 function BuildBE {
     RPOOL=${1:-rpool}
     typeset MEDIA="$2"
-    typeset _bename=${3:-omnios}
+    typeset _bename=${3:-$BENAME}
 
     if [ -z "$MEDIA" ]; then
         BOOTSRVA=`/sbin/dhcpinfo BootSrvA`
@@ -294,7 +302,7 @@ function FetchConfig {
 
 function MakeBootable {
     typeset _rpool=${1:-rpool}
-    typeset _bename=${2:-omnios}
+    typeset _bename=${2:-$BENAME}
     slog "Making boot environment bootable"
     logcmd zpool set bootfs=$_rpool/ROOT/$_bename $_rpool
     # Must do beadm activate first on the off chance we're bootstrapping from


### PR DESCRIPTION
Add a BEName() function, modelled after RootPW(), that lets install
scripts or configuration profiles override the boot environment name
before installation begins.

- BENAME is initialised with ${BENAME:-omnios} so that a value set
   in an environment-specific defs.sh (sourced before install_help.sh)
   is preserved rather than overwritten.

- A companion flag BENAME_SET is cleared at module load and set by
  BEName(). Installer scripts append the OS version from /etc/release
  to the BE name only when BENAME_SET is unset, preserving the
  existing omnios-r151056t naming convention for default installs while
  allowing downstream distributions to supply a fully-formed name that
  is used as-is.

- BuildBE() and MakeBootable() default to $BENAME instead of the
   hardcoded string "omnios", so the PXE/network install path also
   honours the configured name.

- Installer scripts (dialog-install, rpool-install) call BEName $BENAME
  explicitly after sourcing install_help.sh so the function is exercised
  and any pre-set value flows through correctly.